### PR TITLE
[Sandwhich Lady] Fix not highlighting Meat Pie widget answer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 }
 
 group = 'randomeventhelper'
-version = '2.4.3'
+version = '2.4.4'
 
 tasks.withType(JavaCompile).configureEach {
 	options.encoding = 'UTF-8'

--- a/src/main/java/randomeventhelper/randomevents/sandwichlady/SandwichTrayFood.java
+++ b/src/main/java/randomeventhelper/randomevents/sandwichlady/SandwichTrayFood.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum SandwichTrayFood
 {
-	MEAT_PIE(10730, "Meat pie"),
+	MEAT_PIE(10730, "Pie"),
 	KEBAB(10729, "Kebab"),
 	CHOCOLATE_BAR(10728, "Chocolate bar"),
 	BAGUETTE(10726, "Baguette"),


### PR DESCRIPTION
- The label for Meat Pie was written "pie" instead of "meat pie"
- Update plugin to v2.4.4